### PR TITLE
Add Angular users section to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Lightweight framework for old-school RPG GUI in web!
 - [What is it?](#what-is-it)
 - [Key Features](#key-features)
 - [How to use](#how-to-use)
+- [Angular users](#angular-users)
 - [How to tweak](#how-to-tweak)
 - [License](#license)
 - [Contact Me](#contact-me)
@@ -58,6 +59,22 @@ Include the files from the html header, like this:
 
 **The best way to understand PRGUI is to look at the included example and just copy their HTML.** 
 But if you prefer reading material, here's a tutorial that explains about the basic elements of RPGUI and how to use them.
+
+## Angular users
+
+If you are using Angular you may want to include following snippet to your `angular.json`.
+
+```json
+"assets": [
+  "src/favicon.ico",
+  "src/assets"
+],
+"styles": [
+  "src/styles.css",
+  "dist/rpgui.css"
+],
+"scripts": []
+```
 
 ### RPGUI Tutorial
 
@@ -494,3 +511,6 @@ See LICENSE.txt for more info.
 
 For issues / bugs use the Report Issue button.
 For anything else, feel free to contact me: ronenness@gmail.com.
+
+
+[issue-12]: https://github.com/RonenNess/RPGUI/issues/12

--- a/README.md
+++ b/README.md
@@ -511,6 +511,3 @@ See LICENSE.txt for more info.
 
 For issues / bugs use the Report Issue button.
 For anything else, feel free to contact me: ronenness@gmail.com.
-
-
-[issue-12]: https://github.com/RonenNess/RPGUI/issues/12


### PR DESCRIPTION
Since I've had problems with the usage of RPGUI in combination with Angular, I want to merge following changeset into the main project.

It contains a change in the `README.md`, that describes what developers that are stuck on the css implementation should do about it.