### PR TITLE
Fixed Golden Endcaps

### DIFF
--- a/src/styles/_button.scss
+++ b/src/styles/_button.scss
@@ -82,6 +82,9 @@
     padding-left: 35px;
     padding-right: 35px;
     overflow: visible;
+	
+	/* endcap fix */
+	position: relative;
 }
 
 /* button hover */
@@ -110,10 +113,15 @@
     background: transparent url('img/button-golden-left.png') no-repeat right center;
     background-size: 100% 100%;
     margin: 0 0 0 0;
-    left: 0px;
+	
+    /* endcap fix */
+    /* left: 0px; 
     float: left;
     margin-left: -46px;
-    margin-top: -5%;
+    margin-top: -5%; */
+    position: absolute;
+    top: -5%;
+    left: -12px;
 }
 
 .rpgui-button.golden:after
@@ -127,10 +135,15 @@
     background: transparent url('img/button-golden-right.png') no-repeat left center;
     background-size: 100% 100%;
     margin: 0 0 0 0;
-    right: 0px;
-    float: right;
+	
+    /* endcap fix */
+    position: absolute;
+    right: -12px;
+    top: -5%;
+    /* float: right;
     margin-right: -46px;
-    margin-top: -5%;
+    margin-top: -5%; */	
+    
 }
 
 /*


### PR DESCRIPTION
#10  End caps were rising up above the button as the button width was increased do to the -5% margin. Instead, I refactored it using absolute positioning on the pseudo-elements and relative positioning on the button (parent container). 

I'd love to help contribute to this one. Let me know if I can help out.